### PR TITLE
Fixed checkbox in the cms settings for autoAuthorization

### DIFF
--- a/API/public/settings.js
+++ b/API/public/settings.js
@@ -22,7 +22,7 @@ autoAuthentication.addEventListener('change', function() {
   database.ref('/settings/bools/').update({autoAuthentication: status})
     .then(function(){
       //Get the settings
-      return database.ref('/settings/strings/').once('value');
+      return database.ref('/settings/bools/').once('value');
     })
     .then(function(settingsSnapshot){
       //Change the authorization code at the database

--- a/Database/database_example.json
+++ b/Database/database_example.json
@@ -22,7 +22,7 @@
   } ],
   "settings" : {
     "bools" : {
-      "autoAthorization": true
+      "autoAuthorization": true
     },
     "strings" : {
       "codeKey": "-code"


### PR DESCRIPTION
The checkbox in the CMS settings was able to change the value in the database but after reloading the page the state didn't change.